### PR TITLE
License value fix to valid SPDX in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,7 @@
   "version": "1.1.0",
   "description": "Perhaps the most awesome way of interacting with data using a chainable API",
   "homepage": "https://github.com/chainyjs/chainy",
-  "license": {
-    "type": "MIT"
-  },
+  "license": "MIT",
   "badges": {
     "travis": true,
     "npm": true,


### PR DESCRIPTION
The license value in the package.json should be a valid SPDX as documented on (https://docs.npmjs.com/files/package.json#license). This commit fixes it.
